### PR TITLE
Core/Command: Fix a crash when using wp show info pathid

### DIFF
--- a/src/scripts/Commands/cs_wp.cpp
+++ b/src/scripts/Commands/cs_wp.cpp
@@ -783,7 +783,7 @@ public:
         if (show == "info")
         {
             // Check if the user did specify a visual waypoint
-            if (target && target->GetEntry() != VISUAL_WAYPOINT)
+            if (!target || target->GetEntry() != VISUAL_WAYPOINT)
             {
                 handler->PSendSysMessage(LANG_WAYPOINT_VP_SELECT);
                 handler->SetSentErrorMessage(true);


### PR DESCRIPTION
Fix #530 thanks to @BarbzYHOOL for testing

**Changes proposed:**

-  
-  
-  

**Target branch(es):** 1.x/2.x etc.

**Issues addressed:** Closes #

**Tests performed:** (Does it build, tested in-game, etc)

**Known issues and TODO list:**

- [ ] 
- [ ] 

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


